### PR TITLE
Refactor Matrix fan page with Matrix-themed design and better stories

### DIFF
--- a/data/company.json
+++ b/data/company.json
@@ -1,26 +1,38 @@
 [
     {
         "name": "The Matrix",
-        "description": "The Matrix was first released in the United States on March 31, 1999, and grossed over $460 million worldwide. It was well-received by many critics and won four Academy Awards, as well as other accolades, including BAFTA Awards and Saturn Awards. The Matrix was praised for its innovative visual effects, action sequences, cinematography and entertainment value. The film is considered to be among the best science fiction films of all time, and was added to the National Film Registry for preservation in 2012. The success of the film led to the release of two feature film sequels in 2003, The Matrix Reloaded and The Matrix Revolutions, which were also written and directed by the Wachowskis. The Matrix franchise was further expanded through the production of comic books, video games and animated short films, with which the Wachowskis were heavily involved. The franchise has also inspired books and theories expanding on some of the religious and philosophical ideas alluded to in the films. A fourth film is scheduled for release on May 21, 2021.",
+        "year": 1999,
+        "tagline": "What is the Matrix?",
+        "description": "The Matrix (1999) is the groundbreaking sci-fi masterpiece that redefined cinema. Written and directed by the Wachowskis, it follows Thomas Anderson, a computer programmer who discovers that reality as he knows it is a simulated world created by sentient machines to subdue humanity. Under the alias Neo, he is contacted by the mysterious Morpheus, who offers him a choice: take the blue pill and forget everything, or take the red pill and see how deep the rabbit hole goes. Neo chooses the red pill, awakening to a devastated real world where humans are farmed for energy. With training in martial arts downloaded directly into his mind, Neo begins to bend the rules of the Matrix and ultimately embraces his destiny as 'The One' — a prophesied savior who can end the war between humans and machines. The film grossed over $460 million worldwide, won four Academy Awards for its revolutionary visual effects including the iconic 'bullet time' technique, and was added to the National Film Registry in 2012. It remains one of the most influential science fiction films ever made.",
         "image_source": "https://upload.wikimedia.org/wikipedia/en/c/c1/The_Matrix_Poster.jpg",
-        "url": "Matrix"
+        "url": "Matrix",
+        "iconic_quote": "There is no spoon."
     },
     {
         "name": "The Matrix Reloaded",
-        "description": "is a 2003 American science fiction action film written and directed by the Wachowskis.[a] It is the first sequel to The Matrix, and the second installment in The Matrix film franchise. Reloaded premiered on May 7, 2003, in Westwood, Los Angeles, California, and went on general release by Warner Bros. in North American theaters on May 15, 2003, and around the world during the latter half of that month. It was also screened out of competition at the 2003 Cannes Film Festival.[6] The video game Enter the Matrix and The Animatrix, a collection of short animations, supported and expanded the storyline of the film.",
+        "year": 2003,
+        "tagline": "Free your mind.",
+        "description": "The Matrix Reloaded (2003) raises the stakes as Neo, now fully realized as The One, must venture deeper into the Matrix and confront a new level of control. Zion, the last human city buried deep underground, faces annihilation as an army of 250,000 Sentinels drills toward it. Neo, Trinity, and Morpheus race to reach the Source of the Matrix — its mainframe — where Neo is told he must make an impossible choice that will determine the fate of humanity. Along the way, the film delivers breathtaking action: the legendary Burly Brawl where Neo fights a hundred Agent Smiths, and the jaw-dropping freeway chase sequence that took months to film on a purpose-built highway. The film also introduces the Merovingian, the Keymaker, and the enigmatic Architect, expanding the mythology far beyond the original. Reloaded premiered at the 2003 Cannes Film Festival and earned over $742 million worldwide, proving that audiences were hungry for more of the Matrix universe.",
         "image_source": "https://upload.wikimedia.org/wikipedia/en/b/ba/Poster_-_The_Matrix_Reloaded.jpg",
-        "url": "Matrix2"
+        "url": "Matrix2",
+        "iconic_quote": "Choice. The problem is choice."
     },
     {
         "name": "The Matrix Revolutions",
-        "description": "The Matrix Revolutions is a 2003 American science fiction action film written and directed by the Wachowskis.[a] It was the third installment of The Matrix film franchise, released six months following The Matrix Reloaded. The film was released simultaneously in 60 countries on November 5, 2003. While being the final entry in the original trilogy of the series, the Matrix storyline is continued in The Matrix Online. It was the first live-action feature film to be released in both regular and IMAX theaters at the same time. Despite having a mixed reception from critics, the film grossed $427.3 million worldwide. A fourth Matrix film began production in February 2020.",
+        "year": 2003,
+        "tagline": "Everything that has a beginning has an end.",
+        "description": "The Matrix Revolutions (2003) brings the original trilogy to its epic conclusion. With Neo trapped between the Matrix and the machine world, and the Sentinel army hours from destroying Zion, every character must face their ultimate purpose. The Battle of Zion is one of cinema's most massive war sequences — thousands of Sentinels pouring through the dock ceiling while human pilots in APU mechs desperately hold the line. Meanwhile, Neo makes a daring journey to the Machine City itself, offering the machines a deal: he will stop the rogue Agent Smith — who has become a virus threatening to consume both the Matrix and the machine world — in exchange for peace. The climactic showdown between Neo and Smith in a rain-drenched Matrix, with the fate of two civilizations hanging in the balance, remains one of sci-fi's most powerful finales. Released simultaneously in 60 countries on November 5, 2003, it was the first live-action film to debut in both regular and IMAX theaters at the same time, grossing $427 million worldwide.",
         "image_source": "https://upload.wikimedia.org/wikipedia/en/3/34/Matrix_revolutions_ver7.jpg",
-        "url": "Matrix3"
+        "url": "Matrix3",
+        "iconic_quote": "Everything that has a beginning has an end."
     },
     {
-        "name": "The Matrix 4",
-        "description": "The Matrix 4 is an upcoming American science fiction action film and the fourth installment in The Matrix franchise. The film is co-written and directed by Lana Wachowski, one of the two Wachowskis who directed the previous three films. Keanu Reeves, Carrie-Anne Moss, Jada Pinkett Smith, and Lambert Wilson reprise their roles from previous films in the series. The film will be a joint production by Warner Bros. Pictures and Village Roadshow Pictures and is scheduled to be released on May 21, 2021.",
-        "image_source": "https://www.animatedtimes.com/wp-content/uploads/2020/04/3-8.png",
-        "url": "Matrix4"
+        "name": "The Matrix Resurrections",
+        "year": 2021,
+        "tagline": "Return to the source.",
+        "description": "The Matrix Resurrections (2021) reopens the door to the Matrix 18 years after the original trilogy. Directed by Lana Wachowski, the film finds Thomas Anderson living as a successful video game designer in San Francisco, haunted by memories he's told aren't real and medicated with blue pills prescribed by his therapist, the Analyst. When a new version of Morpheus and a rebel named Bugs free him from this new, more sophisticated Matrix, Neo discovers that the machines resurrected both him and Trinity after their sacrifices in Revolutions, keeping them close together as a power source fueled by their connection. The film is both a sequel and a meta-commentary on reboots, sequels, and the nature of storytelling itself. With Keanu Reeves and Carrie-Anne Moss reprising their iconic roles, along with new cast members Yahya Abdul-Mateen II, Jessica Henwick, Jonathan Groff, and Neil Patrick Harris, the film explores how the world has changed — both within the Matrix and in our own reality — while reaffirming that the power of choice and love can break any system of control.",
+        "image_source": "https://upload.wikimedia.org/wikipedia/en/d/d2/The_Matrix_Resurrections.jpg",
+        "url": "Matrix4",
+        "iconic_quote": "The choice is an illusion. You already know what you have to do."
     }
 ]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,362 @@
+/* ===== MATRIX THEME ===== */
+
+/* Import monospace font for Matrix feel */
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+/* Digital rain canvas background */
+#matrix-bg {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    background-color: #000;
+}
+
+/* Base overrides */
+body {
+    background-color: #000 !important;
+    color: #00ff41 !important;
+    font-family: 'Share Tech Mono', 'Courier New', monospace !important;
+}
+
+p {
+    color: #b0ffb0;
+    line-height: 1.7;
+}
+
+a {
+    color: #00ff41 !important;
+    text-shadow: 0 0 5px rgba(0, 255, 65, 0.4);
+    transition: all 0.3s;
+}
+
+a:hover, a:focus {
+    color: #fff !important;
+    text-shadow: 0 0 15px rgba(0, 255, 65, 0.8);
+    text-decoration: none !important;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Share Tech Mono', 'Courier New', monospace !important;
+    color: #00ff41 !important;
+    text-shadow: 0 0 10px rgba(0, 255, 65, 0.5);
+}
+
+hr {
+    border-color: #0a3d0a;
+}
+
+/* Navigation */
+#mainNav {
+    background-color: rgba(0, 0, 0, 0.9) !important;
+    border-bottom: 1px solid #0a3d0a !important;
+    backdrop-filter: blur(10px);
+}
+
+#mainNav .navbar-brand {
+    color: #00ff41 !important;
+    font-family: 'Share Tech Mono', monospace !important;
+    text-shadow: 0 0 10px rgba(0, 255, 65, 0.7);
+    font-size: 1.5rem;
+}
+
+#mainNav .navbar-nav > li.nav-item > a {
+    color: #00ff41 !important;
+    font-family: 'Share Tech Mono', monospace !important;
+}
+
+#mainNav .navbar-nav > li.nav-item > a:hover {
+    color: #fff !important;
+    text-shadow: 0 0 15px rgba(0, 255, 65, 0.8);
+}
+
+#mainNav .navbar-toggler {
+    color: #00ff41 !important;
+    border-color: #0a3d0a;
+}
+
+#mainNav.is-fixed {
+    background-color: rgba(0, 0, 0, 0.95) !important;
+    border-bottom: 1px solid #0a3d0a !important;
+}
+
+#mainNav.is-fixed .navbar-brand {
+    color: #00ff41 !important;
+}
+
+#mainNav.is-fixed .navbar-nav > li.nav-item > a {
+    color: #00ff41 !important;
+}
+
+/* Header / Masthead */
+header.masthead {
+    background-color: #000 !important;
+    position: relative;
+}
+
+header.masthead .overlay {
+    background-color: #000 !important;
+    opacity: 0.7;
+}
+
+header.masthead .site-heading h1 {
+    color: #00ff41 !important;
+    text-shadow: 0 0 20px rgba(0, 255, 65, 0.8), 0 0 40px rgba(0, 255, 65, 0.4);
+    font-family: 'Share Tech Mono', monospace !important;
+    letter-spacing: 8px;
+}
+
+header.masthead .site-heading .subheading {
+    color: #b0ffb0 !important;
+    font-family: 'Share Tech Mono', monospace !important;
+    text-shadow: 0 0 10px rgba(0, 255, 65, 0.3);
+}
+
+/* Post previews on home page */
+.post-preview > a {
+    color: #00ff41 !important;
+}
+
+.post-preview > a:hover {
+    color: #fff !important;
+}
+
+.post-preview > a > .post-title {
+    color: #00ff41;
+    text-shadow: 0 0 8px rgba(0, 255, 65, 0.4);
+}
+
+.post-preview > a > .post-subtitle {
+    color: #80ff80;
+}
+
+.post-preview > .post-meta {
+    color: #2d8a2d !important;
+    font-style: normal;
+    font-family: 'Share Tech Mono', monospace;
+}
+
+.post-preview > .post-meta > a {
+    color: #00ff41 !important;
+}
+
+/* Movie cards on about page */
+.matrix-movie-card {
+    background: rgba(0, 255, 65, 0.03);
+    border: 1px solid #0a3d0a;
+    border-radius: 4px;
+    padding: 30px;
+    margin-bottom: 40px;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.matrix-movie-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, #00ff41, transparent);
+    animation: scanline 3s linear infinite;
+}
+
+@keyframes scanline {
+    0% { left: -100%; }
+    100% { left: 100%; }
+}
+
+.matrix-movie-card:hover {
+    border-color: #00ff41;
+    box-shadow: 0 0 20px rgba(0, 255, 65, 0.15);
+    background: rgba(0, 255, 65, 0.06);
+}
+
+.matrix-movie-card img {
+    border: 1px solid #0a3d0a;
+    transition: all 0.3s ease;
+    max-width: 100%;
+}
+
+.matrix-movie-card:hover img {
+    border-color: #00ff41;
+    box-shadow: 0 0 15px rgba(0, 255, 65, 0.3);
+}
+
+.movie-year {
+    color: #2d8a2d;
+    font-size: 14px;
+    letter-spacing: 3px;
+    margin-bottom: 5px;
+}
+
+.movie-tagline {
+    color: #00ff41;
+    font-style: italic;
+    font-size: 18px;
+    margin: 10px 0 20px;
+    text-shadow: 0 0 5px rgba(0, 255, 65, 0.3);
+}
+
+.iconic-quote {
+    border-left: 2px solid #00ff41;
+    padding: 10px 20px;
+    margin: 20px 0;
+    color: #00ff41;
+    font-style: italic;
+    background: rgba(0, 255, 65, 0.03);
+}
+
+/* Member/detail page */
+.member-detail img {
+    border: 1px solid #0a3d0a;
+    box-shadow: 0 0 20px rgba(0, 255, 65, 0.15);
+}
+
+.member-detail h2 {
+    letter-spacing: 3px;
+}
+
+/* Buttons */
+.btn-primary {
+    background-color: transparent !important;
+    border: 1px solid #00ff41 !important;
+    color: #00ff41 !important;
+    text-shadow: 0 0 5px rgba(0, 255, 65, 0.3);
+    font-family: 'Share Tech Mono', monospace;
+}
+
+.btn-primary:hover, .btn-primary:focus, .btn-primary:active {
+    background-color: #00ff41 !important;
+    border-color: #00ff41 !important;
+    color: #000 !important;
+    text-shadow: none;
+    box-shadow: 0 0 20px rgba(0, 255, 65, 0.4);
+}
+
+/* Footer */
+footer {
+    background-color: #000;
+    border-top: 1px solid #0a3d0a;
+}
+
+footer .copyright {
+    color: #2d8a2d;
+}
+
+footer .fa-stack .fa-circle {
+    color: #0a3d0a;
+    transition: color 0.3s;
+}
+
+footer a:hover .fa-circle {
+    color: #00ff41 !important;
+}
+
+/* Contact form */
+.floating-label-form-group {
+    border-bottom-color: #0a3d0a !important;
+}
+
+.floating-label-form-group input,
+.floating-label-form-group textarea {
+    color: #00ff41 !important;
+    font-family: 'Share Tech Mono', monospace !important;
+    background: transparent !important;
+}
+
+.floating-label-form-group input::-webkit-input-placeholder,
+.floating-label-form-group textarea::-webkit-input-placeholder {
+    color: #2d8a2d !important;
+}
+
+.floating-label-form-group-with-focus label {
+    color: #00ff41 !important;
+}
+
+form .form-group:first-child .floating-label-form-group {
+    border-top-color: #0a3d0a !important;
+}
+
+/* Selection */
+::selection {
+    background: #00ff41 !important;
+    color: #000 !important;
+}
+
+::-moz-selection {
+    background: #00ff41 !important;
+    color: #000 !important;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: #000;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #0a3d0a;
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #00ff41;
+}
+
+/* Featurette image */
 .featurette-image {
     width: 100%;
+}
+
+/* Glitch text effect for main heading */
+.glitch {
+    position: relative;
+}
+
+.glitch::before,
+.glitch::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.glitch::before {
+    animation: glitch-1 2s infinite linear alternate-reverse;
+    clip-path: polygon(0 0, 100% 0, 100% 45%, 0 45%);
+    -webkit-text-stroke: 1px rgba(0, 255, 65, 0.3);
+}
+
+.glitch::after {
+    animation: glitch-2 3s infinite linear alternate-reverse;
+    clip-path: polygon(0 60%, 100% 60%, 100% 100%, 0 100%);
+    -webkit-text-stroke: 1px rgba(0, 255, 65, 0.3);
+}
+
+@keyframes glitch-1 {
+    0% { transform: translateX(0); }
+    20% { transform: translateX(-2px); }
+    40% { transform: translateX(2px); }
+    60% { transform: translateX(-1px); }
+    80% { transform: translateX(1px); }
+    100% { transform: translateX(0); }
+}
+
+@keyframes glitch-2 {
+    0% { transform: translateX(0); }
+    20% { transform: translateX(2px); }
+    40% { transform: translateX(-2px); }
+    60% { transform: translateX(1px); }
+    80% { transform: translateX(-1px); }
+    100% { transform: translateX(0); }
 }

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,54 +1,52 @@
 {% extends 'base.html' %}
 {% block content %}
 
-
-    <h2>{{ page_title }}</h2>
-    <p>The Matrix is an American media franchise created by the Wachowskis. The series primarily consists of a trilogy of science fiction action films beginning with The Matrix (1999) and continuing with two sequels, The Matrix Reloaded and The Matrix Revolutions (both in 2003), all written and directed by the Wachowskis and produced by Joel Silver. The franchise is owned by Warner Bros., which distributed the films along with Village Roadshow Pictures. The latter, along with Silver Pictures, are the two production companies that worked on all three films.
-    </p>
+    <div class="row">
+      <div class="col-lg-8 col-md-10 mx-auto">
+        <h2>{{ page_title }}</h2>
+        <p>The Matrix is an American media franchise created by the Wachowskis — a landmark in science fiction that questioned the nature of reality itself. Beginning with The Matrix (1999), the series expanded into a full trilogy and eventually a fourth film, The Matrix Resurrections (2021). With its fusion of cyberpunk aesthetics, martial arts action, and deep philosophical themes drawn from Plato, Baudrillard, and Buddhist thought, The Matrix didn't just entertain — it changed how we think about technology, free will, and the world around us.</p>
+      </div>
+    </div>
 
     {% for member in company %}
 
-    
-
-    <div class="row featurette">
+    <div class="matrix-movie-card">
+      <div class="row featurette">
 
         {% if loop.index % 2 != 0 %}
 
-    <div class="col-md-7">
-    <h3><a href="/about/{{ member.url }}">{{ loop.index }} {{ member.name }}</a></h3>
-    <p>
-
-    {{ member.description }}
-    
-    </p>
-    </div>
-    <div class="col-md-5">
-    <img class="featurette-image img-responsive" src="{{ member.image_source }}">
-    </div>
+        <div class="col-md-7">
+          <div class="movie-year">// {{ member.year }}</div>
+          <h3><a href="/about/{{ member.url }}">{{ member.name }}</a></h3>
+          <div class="movie-tagline">"{{ member.tagline }}"</div>
+          <p>{{ member.description }}</p>
+          <div class="iconic-quote">
+            "{{ member.iconic_quote }}"
+          </div>
+        </div>
+        <div class="col-md-5">
+          <img class="featurette-image img-responsive" src="{{ member.image_source }}" alt="{{ member.name }} poster">
+        </div>
 
         {% else %}
 
         <div class="col-md-5">
-    <img class="featurette-image img-responsive" src="{{ member.image_source }}">
-    </div>
-    <div class="col-md-7">
-    <h3><a href="/about/{{ member.url }}">{{ loop.index }} {{ member.name }}</a></h3>
-    <p>
-
-    {{ member.description }}
-    
-    </p>
-    </div>
+          <img class="featurette-image img-responsive" src="{{ member.image_source }}" alt="{{ member.name }} poster">
+        </div>
+        <div class="col-md-7">
+          <div class="movie-year">// {{ member.year }}</div>
+          <h3><a href="/about/{{ member.url }}">{{ member.name }}</a></h3>
+          <div class="movie-tagline">"{{ member.tagline }}"</div>
+          <p>{{ member.description }}</p>
+          <div class="iconic-quote">
+            "{{ member.iconic_quote }}"
+          </div>
+        </div>
 
         {% endif %}
 
+      </div>
     </div>
-
-    {% if loop.index != 4 %}
-
-    <hr class="featurette-divider">
-    
-    {% endif %}
 
     {% endfor %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,13 +7,16 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/bootstrap/css/bootstrap.min.css') }}">
     <link  rel="stylesheet" href="{{ url_for('static', filename='css/clean-blog.min.css') }}">
     <link  rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <title>Hello Flask</title>
+    <title>The Matrix Fan Page</title>
 </head>
 <body>
+    <!-- Matrix digital rain background -->
+    <canvas id="matrix-bg"></canvas>
+
     <!-- Navigation -->
   <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
     <div class="container">
-      <a class="navbar-brand" href="{{ url_for('index') }}">Matrix</a>
+      <a class="navbar-brand" href="{{ url_for('index') }}">[ MATRIX ]</a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         Menu
         <i class="fas fa-bars"></i>
@@ -24,10 +27,7 @@
             <a class="nav-link" href="{{ url_for('index') }}">Home</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('about') }}">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('careers') }}">Careers</a>
+            <a class="nav-link" href="{{ url_for('about') }}">The Films</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('contact') }}">Contact</a>
@@ -44,8 +44,8 @@
       <div class="row">
         <div class="col-lg-8 col-md-10 mx-auto">
           <div class="site-heading">
-            <h1>Matrix</h1>
-            <span class="subheading">That’s how it is with people. Nobody cares how it works as long as it works.</span>
+            <h1 class="glitch" data-text="THE MATRIX">THE MATRIX</h1>
+            <span class="subheading">Wake up, Neo... The Matrix has you.</span>
           </div>
         </div>
       </div>
@@ -54,7 +54,7 @@
 
   <!-- Main Content -->
   <div class="container">
-    
+
         {% block content %}
         {% endblock %}
 
@@ -93,7 +93,7 @@
               </a>
             </li>
           </ul>
-          <p class="copyright text-muted">Copyright &copy; Your Website 2019</p>
+          <p class="copyright text-muted">The Matrix is a registered trademark of Warner Bros. | Fan Page &copy; 2024</p>
         </div>
       </div>
     </div>
@@ -105,6 +105,49 @@
 
   <!-- Custom scripts for this template -->
   <script src="{{ url_for('static', filename='js/clean-blog.min.js') }}"></script>
+
+  <!-- Matrix digital rain effect -->
+  <script>
+    const canvas = document.getElementById('matrix-bg');
+    const ctx = canvas.getContext('2d');
+
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+
+    const chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const fontSize = 14;
+    const columns = canvas.width / fontSize;
+    const drops = [];
+
+    for (let i = 0; i < columns; i++) {
+      drops[i] = Math.random() * -100;
+    }
+
+    function drawMatrix() {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#00ff41';
+      ctx.font = fontSize + 'px monospace';
+
+      for (let i = 0; i < drops.length; i++) {
+        const text = chars[Math.floor(Math.random() * chars.length)];
+        ctx.fillStyle = 'rgba(0, 255, 65, ' + (Math.random() * 0.5 + 0.1) + ')';
+        ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+
+        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) {
+          drops[i] = 0;
+        }
+        drops[i]++;
+      }
+    }
+
+    setInterval(drawMatrix, 50);
+
+    window.addEventListener('resize', function() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    });
+  </script>
 
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,61 +3,78 @@
       <div class="row">
       <div class="col-lg-8 col-md-10 mx-auto">
         <div class="post-preview">
-          <a href="post.html">
+          <a href="{{ url_for('about') }}">
             <h2 class="post-title">
-              Man must explore, and this is exploration at its greatest
+              The Red Pill: How The Matrix Changed Cinema Forever
             </h2>
             <h3 class="post-subtitle">
-              Problems look mighty small from 150 miles up
+              From bullet time to philosophical awakening — a look at why the 1999 masterpiece still resonates today.
             </h3>
           </a>
-          <p class="post-meta">Posted by
-            <a href="#">Start Bootstrap</a>
-            on September 24, 2019</p>
+          <p class="post-meta">> system.log
+            <a href="#">Morpheus</a>
+            // 1999.03.31</p>
         </div>
         <hr>
         <div class="post-preview">
-          <a href="post.html">
+          <a href="{{ url_for('about_member', member_name='Matrix2') }}">
             <h2 class="post-title">
-              I believe every human has a finite number of heartbeats. I don't intend to waste any of mine.
+              The Burly Brawl: Behind the 100 Agent Smiths
             </h2>
+            <h3 class="post-subtitle">
+              How groundbreaking VFX and months of choreography created the most ambitious fight scene in film history.
+            </h3>
           </a>
-          <p class="post-meta">Posted by
-            <a href="#">Start Bootstrap</a>
-            on September 18, 2019</p>
+          <p class="post-meta">> system.log
+            <a href="#">The Architect</a>
+            // 2003.05.15</p>
         </div>
         <hr>
         <div class="post-preview">
-          <a href="post.html">
+          <a href="{{ url_for('about_member', member_name='Matrix3') }}">
             <h2 class="post-title">
-              Science has not yet mastered prophecy
+              The Battle of Zion: Humanity's Last Stand
             </h2>
             <h3 class="post-subtitle">
-              We predict too much for the next year and yet far too little for the next ten.
+              Inside the epic siege sequence that pushed visual effects to their absolute limits.
             </h3>
           </a>
-          <p class="post-meta">Posted by
-            <a href="#">Start Bootstrap</a>
-            on August 24, 2019</p>
+          <p class="post-meta">> system.log
+            <a href="#">Commander Lock</a>
+            // 2003.11.05</p>
         </div>
         <hr>
         <div class="post-preview">
-          <a href="post.html">
+          <a href="{{ url_for('about_member', member_name='Matrix') }}">
             <h2 class="post-title">
-              Failure is not an option
+              "There Is No Spoon" — The Philosophy Behind The Matrix
             </h2>
             <h3 class="post-subtitle">
-              Many say exploration is part of our destiny, but it’s actually our duty to future generations.
+              Plato's Cave, Descartes' demon, and Buddhist enlightenment — the ideas that shaped a franchise.
             </h3>
           </a>
-          <p class="post-meta">Posted by
-            <a href="#">Start Bootstrap</a>
-            on July 8, 2019</p>
+          <p class="post-meta">> system.log
+            <a href="#">The Oracle</a>
+            // 1999.03.31</p>
+        </div>
+        <hr>
+        <div class="post-preview">
+          <a href="{{ url_for('about_member', member_name='Matrix4') }}">
+            <h2 class="post-title">
+              Resurrections: Returning to the Source After 18 Years
+            </h2>
+            <h3 class="post-subtitle">
+              Lana Wachowski's meta-commentary on reboots, nostalgia, and the systems that keep us plugged in.
+            </h3>
+          </a>
+          <p class="post-meta">> system.log
+            <a href="#">The Analyst</a>
+            // 2021.12.22</p>
         </div>
         <hr>
         <!-- Pager -->
         <div class="clearfix">
-          <a class="btn btn-primary float-right" href="#">Older Posts &rarr;</a>
+          <a class="btn btn-primary float-right" href="{{ url_for('about') }}">Explore The Films &rarr;</a>
         </div>
       </div>
     </div>

--- a/templates/member.html
+++ b/templates/member.html
@@ -1,15 +1,22 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="row">
+<div class="matrix-movie-card member-detail">
+  <div class="row">
     <div class="col-md-5">
-        <img src="{{ member.image_source }}" alt="Profile image for {{ member.name }}" />
-        <h2 class="col-md-7">{{ member.name }}</h2>
+      <img src="{{ member.image_source }}" alt="Poster for {{ member.name }}" class="featurette-image img-responsive" />
     </div>
-</div>
-
-<div class="col-md-12">
-    <p>{{ member.description }}</p>
+    <div class="col-md-7">
+      <div class="movie-year">// {{ member.year }}</div>
+      <h2>{{ member.name }}</h2>
+      <div class="movie-tagline">"{{ member.tagline }}"</div>
+      <p>{{ member.description }}</p>
+      <div class="iconic-quote">
+        "{{ member.iconic_quote }}"
+      </div>
+      <a href="{{ url_for('about') }}" class="btn btn-primary mt-4">&larr; Back to All Films</a>
+    </div>
+  </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
- Add falling digital rain (green characters) canvas background effect
- Restyle entire site with Matrix green-on-black color scheme, monospace font
- Replace generic placeholder blog posts with Matrix-themed stories and articles
- Update movie data with detailed descriptions, taglines, iconic quotes, and years
- Update Matrix 4 entry to "The Matrix Resurrections" (2021) with accurate info
- Add glitch text effect on main heading, scanline animations on movie cards
- Redesign movie cards with hover effects, border glow, and quote sections
- Update member detail page with consistent Matrix styling
- Remove unused Careers nav link

https://claude.ai/code/session_01Qi8P7fYtvxJkmNpb8zgnca